### PR TITLE
Include main.js only once, at the end of the body

### DIFF
--- a/sample-index.html
+++ b/sample-index.html
@@ -5,7 +5,6 @@
   <meta name="description" content="155 characters of call to action">
   <title>PAGE TITLE HERE</title>
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-  <script src="main.js"></script>
 </head>
   <body style="margin-left:25%">
     <img alt='jessiezack' src='http://justjokin.files.wordpress.com/2014/02/jessie-i-learned-jquery-omg-what-happened-in-the-document-ready-software-jokes-5-justjok-in.jpg'>
@@ -39,6 +38,6 @@
     <td>Purple Heron</td>
   </tr>
 </table>
-  </body>
   <script type='text/javascript' src='main.js'></script>
+  </body>
 </html>


### PR DESCRIPTION
For some reason, the `main.js` was included twice, and the second one was after the closing body tag.
